### PR TITLE
Adding GitHub CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+*.py @random1on1s/DevTeam
+.github/* @qwinters


### PR DESCRIPTION
CODEOWNERS => these people will be automatically requested on all relevant PRs (we can eventually make it so that this acts as access control as well if we ever wind up taking open source contributions) 